### PR TITLE
fix: add __name polyfill to fix esbuild helper error “_name is not defined”

### DIFF
--- a/_workers_next/src/app/layout.tsx
+++ b/_workers_next/src/app/layout.tsx
@@ -111,6 +111,14 @@ export default async function RootLayout({
         ["--theme-primary-dark-l" as any]: themePrimaryDarkL,
       }}
     >
+      <head>
+        {/* Polyfill for esbuild's __name helper - fixes "__name is not defined" error on Cloudflare Workers */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `var __name = function(fn, name) { return Object.defineProperty(fn, "name", { value: name, configurable: true }); };`,
+          }}
+        />
+      </head>
       <body className={cn("min-h-screen bg-background font-sans antialiased", inter.className)}>
         <Providers themeColor={themeColor}>
           <div className="relative flex min-h-screen flex-col">


### PR DESCRIPTION
前台和后台所有页面都会出现 __name is not defined 的报错

构建过程无错误，问题仅在运行时出现

> 应该是  esbuild 在打包时会使用 `keepNames` 选项，为函数添加 `__name` helper 来保留函数名用于调试。但在 Cloudflare Workers 运行时环境中，这个 helper 函数没有被正确注入到客户端 JavaScript bundle 中。