### PR TITLE
feat: 自定义页脚支持富文本(HTML)格式

### DIFF
--- a/_workers_next/src/app/globals.css
+++ b/_workers_next/src/app/globals.css
@@ -453,3 +453,16 @@
   color: hsl(var(--ring));
   transform: translateY(0) scale(0.95);
 }
+
+/* ======================================
+   FOOTER HTML STYLES
+   ====================================== */
+.footer-html a {
+  color: var(--muted-foreground);
+  text-decoration: none;
+  transition: color 0.3s ease;
+}
+
+.footer-html a:hover {
+  color: var(--primary);
+}

--- a/_workers_next/src/components/admin/settings-content.tsx
+++ b/_workers_next/src/components/admin/settings-content.tsx
@@ -6,6 +6,7 @@ import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
 import { Label } from "@/components/ui/label"
 import { TrendingUp, ShoppingCart, CreditCard, Package, Users } from "lucide-react"
 import { saveShopName, saveShopDescription, saveShopLogo, saveShopFooter, saveThemeColor, saveLowStockThreshold, saveCheckinReward, saveCheckinEnabled, saveWishlistEnabled, saveNoIndex, saveRefundReclaimCards, saveRegistryHideNav } from "@/actions/admin"
@@ -500,11 +501,13 @@ export function AdminSettingsContent({ stats, shopName, shopDescription, shopLog
                 <CardContent className="space-y-4">
                     <div className="grid gap-2 md:max-w-xl">
                         <div className="flex gap-2">
-                            <Input
+                            <Textarea
                                 id="shop-footer"
                                 value={shopFooterValue}
                                 onChange={(e) => setShopFooterValue(e.target.value)}
                                 placeholder={t('admin.settings.footer.placeholder')}
+                                rows={3}
+                                className="font-mono text-sm"
                             />
                             <Button variant="outline" onClick={handleSaveShopFooter} disabled={savingShopFooter}>
                                 {savingShopFooter ? t('common.processing') : t('common.save')}
@@ -531,21 +534,21 @@ export function AdminSettingsContent({ stats, shopName, shopDescription, shopLog
                                 : 'transparent'
 
                             return (
-                            <button
-                                key={value}
-                                onClick={() => handleSaveTheme(value)}
-                                disabled={savingTheme}
-                                className={`
+                                <button
+                                    key={value}
+                                    onClick={() => handleSaveTheme(value)}
+                                    disabled={savingTheme}
+                                    className={`
                                     w-12 h-12 rounded-full border-2 transition-all
                                     ${selectedTheme === value ? 'ring-2 ring-offset-2 ring-foreground scale-110' : 'hover:scale-105'}
                                     ${savingTheme ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}
                                 `}
-                                style={{
-                                    backgroundColor: bgColor,
-                                    borderColor
-                                }}
-                                title={t(`admin.settings.themeColor.${value}`)}
-                            />
+                                    style={{
+                                        backgroundColor: bgColor,
+                                        borderColor
+                                    }}
+                                    title={t(`admin.settings.themeColor.${value}`)}
+                                />
                             )
                         })}
                     </div>

--- a/_workers_next/src/components/footer-content.tsx
+++ b/_workers_next/src/components/footer-content.tsx
@@ -72,9 +72,10 @@ export function FooterContent({ customFooter, version }: FooterContentProps) {
         <footer className="border-t border-border/50 py-6 pb-20 md:py-0 md:pb-0 bg-gradient-to-t from-muted/30 to-transparent">
             <div className="container flex flex-col items-center justify-between gap-4 md:h-20 md:flex-row">
                 <div className="flex flex-col items-center gap-4 px-8 md:flex-row md:gap-2 md:px-0">
-                    <p className="text-center text-xs leading-loose text-muted-foreground/80 md:text-left">
-                        {renderFooterText(footerText)}
-                    </p>
+                    <p
+                        className="text-center text-xs leading-loose text-muted-foreground/80 md:text-left footer-html"
+                        dangerouslySetInnerHTML={{ __html: footerText }}
+                    />
                 </div>
                 <a href="https://github.com/chatgptuk/ldc-shop" target="_blank" rel="noreferrer" className="text-center text-xs text-muted-foreground/40 hover:text-primary transition-colors duration-300">
                     v{version}


### PR DESCRIPTION
- 将页脚输入从 Input 改为多行 Textarea
- 使用 dangerouslySetInnerHTML 渲染 HTML
- 添加链接悬停样式
- 
<img width="1416" height="452" alt="CleanShot 2026-02-03 at 22 01 57@2x" src="https://github.com/user-attachments/assets/d05270e5-8281-430a-a104-e06a5ea5dfed" />

自定义页脚支持html格式