### PR TITLE
Workers: patch Cache-Control for /_next/static and document build com…

### DIFF
--- a/_workers_next/README.md
+++ b/_workers_next/README.md
@@ -97,8 +97,13 @@
 2. 选择 **Connect to Git**，连接你的 GitHub/GitLab 仓库
 3. 配置构建设置：
    - **Path**: `_workers_next`
-   - **Build command**: `npm install && npx opennextjs-cloudflare build`
+   - **Build command**: `npm install && npx opennextjs-cloudflare build && node scripts/patch-worker-cache.mjs`
    - **Deploy command**: `npx wrangler deploy`
+
+   > 为什么要加 `patch-worker-cache.mjs`？
+   > 
+   > 部分 Workers 部署会导致 `/_next/static/*` 返回 `Cache-Control: max-age=0`，浏览器无法缓存 Next.js 的静态资源（CSS/JS），从而出现“每次打开都很慢”。
+   > 该脚本会在构建后对 `.open-next/worker.js` 做一次小补丁，强制给 `/_next/static/*` 加上长缓存头：`public, max-age=31536000, immutable`。
 
 4. 点击 **Deploy**
 

--- a/_workers_next/package.json
+++ b/_workers_next/package.json
@@ -7,7 +7,7 @@
     "build": "next build --webpack",
     "start": "next start",
     "lint": "eslint",
-    "deploy": "opennextjs-cloudflare build && wrangler deploy"
+    "deploy": "opennextjs-cloudflare build && node scripts/patch-worker-cache.mjs && wrangler deploy"
   },
   "dependencies": {
     "@opennextjs/cloudflare": "^1.15.1",

--- a/_workers_next/scripts/patch-worker-cache.mjs
+++ b/_workers_next/scripts/patch-worker-cache.mjs
@@ -1,0 +1,42 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const workerPath = path.join(process.cwd(), '.open-next', 'worker.js');
+
+if (!fs.existsSync(workerPath)) {
+  console.error(`[patch-worker-cache] Not found: ${workerPath}. Run \"opennextjs-cloudflare build\" first.`);
+  process.exit(1);
+}
+
+let src = fs.readFileSync(workerPath, 'utf8');
+
+if (src.includes('OPENNEXT_STATIC_CACHE_PATCH')) {
+  console.log('[patch-worker-cache] Patch already applied.');
+  process.exit(0);
+}
+
+const needle = 'const url = new URL(request.url);';
+const idx = src.indexOf(needle);
+if (idx === -1) {
+  console.error('[patch-worker-cache] Could not find insertion point in worker.js');
+  process.exit(1);
+}
+
+const insert = `const url = new URL(request.url);
+            // OPENNEXT_STATIC_CACHE_PATCH: force long-lived caching for Next.js build assets
+            // Without this, some deployments return Cache-Control: max-age=0 for /_next/static/*,
+            // causing slow repeat loads.
+            if (url.pathname.startsWith("/_next/static/")) {
+                const assetResp = await env.ASSETS.fetch(request);
+                const headers = new Headers(assetResp.headers);
+                headers.set("Cache-Control", "public, max-age=31536000, immutable");
+                return new Response(assetResp.body, {
+                    status: assetResp.status,
+                    statusText: assetResp.statusText,
+                    headers,
+                });
+            }`;
+
+src = src.replace(needle, insert);
+fs.writeFileSync(workerPath, src, 'utf8');
+console.log('[patch-worker-cache] Applied static cache patch to .open-next/worker.js');


### PR DESCRIPTION
## Why
Some Workers deployments return `Cache-Control: max-age=0` for `/_next/static/*`, causing CSS/JS to be revalidated on every visit and making the storefront feel slow.

## What
- Add a tiny post-build patch script: `_workers_next/scripts/patch-worker-cache.mjs`
- Document the required Cloudflare Workers Builds `Build command` in `_workers_next/README.md`

## Result
For `/_next/static/*`, the worker serves assets via `env.ASSETS.fetch()` and forces:
`Cache-Control: public, max-age=31536000, immutable`
