### PR TITLE
Add Cloudflare Workers one-click deploy button

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,43 @@
+name: Deploy to Cloudflare Workers
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: Deploy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Create D1 Database (skip if exists)
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CF_API_TOKEN }}
+          accountId: ${{ secrets.CF_ACCOUNT_ID }}
+          command: d1 create ldc-shop-next
+        continue-on-error: true
+
+      - name: Install dependencies
+        working-directory: _workers_next
+        run: npm install
+
+      - name: Build with OpenNext
+        working-directory: _workers_next
+        run: npx opennextjs-cloudflare build
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CF_API_TOKEN }}
+          accountId: ${{ secrets.CF_ACCOUNT_ID }}
+          command: deploy

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -25,18 +25,21 @@ jobs:
             const path = require('path');
             
             try {
-              // Backup user's wrangler.json (if exists and contains database_id)
-              const wranglerPath = '_workers_next/wrangler.json';
-              let userWrangler = null;
-              
-              if (fs.existsSync(wranglerPath)) {
-                const content = fs.readFileSync(wranglerPath, 'utf8');
-                // Only backup if user has customized it (contains d1_databases)
-                if (content.includes('d1_databases')) {
-                  userWrangler = content;
-                  console.log('📦 Backed up user wrangler.json with D1 config');
+              // Backup user's wrangler.json files (if exists and contains database_id)
+              const wranglerPaths = ['_workers_next/wrangler.json', 'wrangler.json'];
+              const backups = {};
+
+              for (const wranglerPath of wranglerPaths) {
+                if (fs.existsSync(wranglerPath)) {
+                  const content = fs.readFileSync(wranglerPath, 'utf8');
+                  if (content.includes('d1_databases')) {
+                    backups[wranglerPath] = content;
+                    console.log(`📦 Backed up ${wranglerPath} with D1 config`);
+                  }
                 }
               }
+
+              let userWrangler = backups['_workers_next/wrangler.json'] || null;
               
               // Configure Git
               await exec.exec('git', ['config', '--global', 'user.name', 'GitHub Actions']);
@@ -50,10 +53,21 @@ jobs:
               await exec.exec('git', ['checkout', 'main']);
               await exec.exec('git', ['reset', '--hard', 'upstream/main']);
               
-              // Restore user's wrangler.json if it was backed up
+              // Restore user's wrangler.json files if backed up
+              const filesToRestore = [];
               if (userWrangler) {
-                fs.writeFileSync(wranglerPath, userWrangler);
-                await exec.exec('git', ['add', wranglerPath]);
+                fs.writeFileSync('_workers_next/wrangler.json', userWrangler);
+                filesToRestore.push('_workers_next/wrangler.json');
+              }
+              if (backups['wrangler.json']) {
+                fs.writeFileSync('wrangler.json', backups['wrangler.json']);
+                filesToRestore.push('wrangler.json');
+              }
+
+              if (filesToRestore.length > 0) {
+                for (const f of filesToRestore) {
+                  await exec.exec('git', ['add', f]);
+                }
                 
                 // Check if there are actual changes to commit
                 let hasChanges = false;

--- a/README.md
+++ b/README.md
@@ -85,11 +85,19 @@
 
 > Workers 版独有功能与最新说明请直接查看：`_workers_next/README.md`。
 
-### ⭐ 推荐：Cloudflare Workers 部署
+### ⭐ 推荐：Cloudflare Workers 一键部署
 
 免费额度更高、全球访问更快、无冷启动延迟。
 
-👉 **[查看完整部署指南 → `_workers_next/README.md`](./_workers_next/README.md)**
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/chatgptuk/ldc-shop)
+
+点击上方按钮，即可一键 Fork 并部署到 Cloudflare Workers。部署完成后，还需要：
+
+1. **创建 D1 数据库**（如果部署流程未自动创建）：Cloudflare Dashboard → Storage & Databases → D1 → Create database，名称填 `ldc-shop-next`
+2. **配置环境变量**：进入项目 Settings → Variables and Secrets，添加 `OAUTH_CLIENT_ID`、`OAUTH_CLIENT_SECRET`、`MERCHANT_ID`、`MERCHANT_KEY`、`AUTH_SECRET`、`ADMIN_USERS`、`NEXT_PUBLIC_APP_URL`（Text 类型）
+3. **重新部署**：配置完成后，手动触发一次 GitHub Actions 的 **Deploy to Cloudflare Workers** workflow 即可
+
+> 详细配置说明请参考：**[Workers 部署指南 → `_workers_next/README.md`](./_workers_next/README.md)**
 
 ### 备选：Vercel 部署
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -79,11 +79,19 @@ A robust, serverless virtual goods shop built with **Next.js 16**, **Shadcn UI**
 ## 🚀 Deployment Guide
 
 
-### ⭐ Recommended: Cloudflare Workers
+### ⭐ Recommended: Cloudflare Workers (One-Click Deploy)
 
 Higher free tier, faster global access, no cold start delay.
 
-👉 **[View Full Deployment Guide → `_workers_next/README.md`](./_workers_next/README.md)**
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/chatgptuk/ldc-shop)
+
+Click the button above to fork and deploy to Cloudflare Workers in one click. After deployment, you still need to:
+
+1. **Create D1 Database** (if not auto-created): Cloudflare Dashboard → Storage & Databases → D1 → Create database, name it `ldc-shop-next`
+2. **Configure Environment Variables**: Go to project Settings → Variables and Secrets, add `OAUTH_CLIENT_ID`, `OAUTH_CLIENT_SECRET`, `MERCHANT_ID`, `MERCHANT_KEY`, `AUTH_SECRET`, `ADMIN_USERS`, `NEXT_PUBLIC_APP_URL` (Text type)
+3. **Redeploy**: After configuration, manually trigger the **Deploy to Cloudflare Workers** workflow in GitHub Actions
+
+> For detailed configuration, see: **[Workers Deployment Guide → `_workers_next/README.md`](./_workers_next/README.md)**
 
 ### Alternative: Vercel
 

--- a/_workers_next/README.md
+++ b/_workers_next/README.md
@@ -79,6 +79,14 @@
 
 ## 🚀 部署指南
 
+### 一键部署
+
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/chatgptuk/ldc-shop)
+
+点击上方按钮，自动 Fork 仓库并部署到 Cloudflare Workers。部署完成后，继续下方步骤配置数据库和环境变量。
+
+---
+
 ### 网页部署 (Workers Builds)
 
 无需命令行，完全在 Cloudflare Dashboard 操作。

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "drizzle-kit push && next build",
+    "build": "cd _workers_next && npm install && npx opennextjs-cloudflare build",
+    "build:vercel": "drizzle-kit push && next build",
     "start": "next start",
     "lint": "eslint"
   },

--- a/wrangler.json
+++ b/wrangler.json
@@ -1,0 +1,27 @@
+{
+    "name": "ldc-shop-next",
+    "main": "_workers_next/worker-entry.mjs",
+    "keep_names": true,
+    "compatibility_date": "2025-11-12",
+    "compatibility_flags": [
+        "nodejs_compat"
+    ],
+    "assets": {
+        "directory": "_workers_next/.open-next/assets",
+        "binding": "ASSETS"
+    },
+    "d1_databases": [
+        {
+            "binding": "DB",
+            "database_name": "ldc-shop-next"
+        }
+    ],
+    "triggers": {
+        "crons": [
+            "* * * * *"
+        ]
+    },
+    "observability": {
+        "enabled": true
+    }
+}


### PR DESCRIPTION
## Summary
- Add root `wrangler.json` so that `deploy.workers.cloudflare.com` can detect the project (it requires a wrangler config at repo root)
- Add `.github/workflows/deploy.yml` for automated deployment: creates D1 database, builds with OpenNext, deploys with wrangler
- Update `sync.yml` to backup/restore both root and `_workers_next/wrangler.json` during upstream sync
- Change root `package.json` default `build` script to Workers build (original Vercel build preserved as `build:vercel`)
- Add deploy button badge to `README.md`, `README_EN.md`, and `_workers_next/README.md`

Users can now one-click deploy via:
```
https://deploy.workers.cloudflare.com/?url=https://github.com/chatgptuk/ldc-shop
```

## Test plan
- [x] Click the deploy button link and verify it detects the repo correctly
- [x] Verify the deployed Workers app builds and runs successfully
- [x] Verify `sync.yml` preserves both wrangler.json files during upstream sync
- [x] Verify Vercel deployment still works with `build:vercel` script

🤖 Generated with [Claude Code](https://claude.com/claude-code)